### PR TITLE
Create k8s-infra-live.sts.yml

### DIFF
--- a/.github/chainguard/k8s-infra-live.sts.yml
+++ b/.github/chainguard/k8s-infra-live.sts.yml
@@ -1,0 +1,11 @@
+# subject pattern is defining what repo and branch is allowed to generate a token at the permission level set below
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:liatrio/k8s-platform-v3-infra-live"
+
+permissions:
+  contents: read
+
+# want to make infra modules and mono repo readable by infra live (subject)
+repositories:
+  - k8s-platform-v3-infra-modules
+  - k8s-platform-v3-monorepo


### PR DESCRIPTION
Could use some eyes on this as this is my first time. I am setting up workflows that will use the octo-sts/action to generate my github tokens. The workflow lives in the k8s-platform-v3-infra-live repo, and the workflow will need to generate a token that allows read permissions to the infra-modules and monorepo. Hopefully I set this up correct but I'm unsure on the syntax for the subject regarding branches.