### PR TITLE
Add catalog-info.yaml for Backstage integration

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,11 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: .github
+  description: Liatrio's GitHub Profile
+  annotations:
+    github.com/project-slug: liatrio/.github
+spec:
+  type: service
+  lifecycle: production
+  owner: team-platform


### PR DESCRIPTION
This PR adds a catalog-info.yaml file to enable integration with Backstage.

Automatically generated by the catalog tool.