### PR TITLE
chore: remove archived autogov-helper from autogov-infra STS config

### DIFF
--- a/.github/chainguard/autogov-infra.sts.yaml
+++ b/.github/chainguard/autogov-infra.sts.yaml
@@ -7,7 +7,6 @@ permissions:
 
 repositories:
   - autogov
-  - autogov-helper
   - autogov-solutions
   - liatrio-rego-policy-library
   - demo-gh-autogov-policy-library


### PR DESCRIPTION
## Summary

- Removes `autogov-helper` from the `autogov-infra` octo-sts trust policy repositories list
- The `autogov-helper` repo has been archived — its functionality was consolidated into the `autogov` CLI as `autogov predicate metadata` and `autogov predicate depscan` (available since v0.20.0)
- Workflow migration PR: https://github.com/liatrio/liatrio-gh-autogov-workflows/pull/330

## Test plan

- [ ] Verify no workflows still reference `autogov-helper` (confirmed — zero references after workflow migration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated infrastructure configuration to adjust repository access settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->