### PR TITLE
feat: add org-level release-ops octo-sts trust policy

### DIFF
--- a/.github/chainguard/release-ops.sts.yaml
+++ b/.github/chainguard/release-ops.sts.yaml
@@ -1,0 +1,15 @@
+issuer: https://token.actions.githubusercontent.com
+subject_pattern: "repo:liatrio/.*:ref:refs/heads/main"
+
+permissions:
+  actions: read
+  contents: write
+  packages: write
+
+repositories:
+  - liatrio-gh-autogov-workflows
+  - liatrio-gh-autogov-caller-workflows
+  - demo-gh-autogov-workflows
+  - demo-gh-autogov-caller-workflows
+  - liatrio-rego-policy-library
+  - demo-gh-autogov-policy-library


### PR DESCRIPTION
## Summary

- Add `release-ops.sts.yaml` at the org level so external caller repos can obtain release tokens
- Previously this trust policy lived only in `liatrio-gh-autogov-workflows` and only allowed that repo as a subject
- The org-level policy allows any `liatrio/*` repo on `main` to request a release-ops token with `contents: write` and `packages: write` for the listed autogov repositories

**Companion PRs:**
- liatrio/liatrio-gh-autogov-workflows — changes `rw-release.yaml` scope from `liatrio/liatrio-gh-autogov-workflows` to `liatrio` and removes the repo-level trust policy

## Test plan
- [ ] Merge this first, then the companion workflow PR
- [ ] Verify `liatrio-gh-autogov-caller-workflows` CI release step succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented OIDC-based trust configuration for GitHub Actions CI/CD workflows to enhance overall security infrastructure. Establishes stricter access controls by restricting automated deployment and release permissions to specific authorized branches and repositories with fine-grained permission management. Enables safer and more controlled automated operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->