### PR TITLE
feat(chainguard): add skills-discovery trust policy

### DIFF
--- a/.github/chainguard/skills-discovery.sts.yaml
+++ b/.github/chainguard/skills-discovery.sts.yaml
@@ -1,0 +1,9 @@
+issuer: https://token.actions.githubusercontent.com
+# Allow skills-platform's discovery workflow to enumerate
+# and read skill repos across the org
+subject_pattern: "repo:liatrio/skills-platform:.*"
+
+permissions:
+  contents: read
+  metadata: read
+  packages: read


### PR DESCRIPTION
## Summary

Adds a trust policy that allows the `Discovery Refresh` workflow in [`liatrio/skills-platform`](https://github.com/liatrio/skills-platform) to mint short-lived installation tokens for reading skill repos across the `liatrio` org.

This is the org-side half of [liatrio/skills-platform#79](https://github.com/liatrio/skills-platform/pull/79), which closes R-002 — currently the catalog at https://skills.liatr.io cannot see internal/private skill repos because the workflow only has the repo-scoped `GITHUB_TOKEN`.

## What it grants

`subject_pattern: "repo:liatrio/skills-platform:.*"` — only the `skills-platform` repo's workflows can mint via the `skills-discovery` identity.

`permissions: contents/metadata/packages: read` — read-only, sufficient to:
- Search `liatrio` for repos with the `agent-skill` topic
- Fetch `SKILL.md` from each
- Read GHCR package versions + manifests for those repos

Matches house style (compare `liatrio-get-all-docs.sts.yaml`, `contract-consumer.sts.yaml`, etc.).

## Test plan

- [ ] Merge this PR
- [ ] Merge the parallel PR in `liatrio-labs/.github`
- [ ] Trigger https://github.com/liatrio/skills-platform/pull/79 via `workflow_dispatch`; confirm the `Exchange OIDC for liatrio installation token` step succeeds and the Discovery Report lists previously-invisible internal repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced security configuration for automated workflows with stricter permission controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/liatrio/.github/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->