### PR TITLE
chore(release-ops): add autogov to the release-ops trust policy

### DIFF
--- a/.github/chainguard/release-ops.sts.yaml
+++ b/.github/chainguard/release-ops.sts.yaml
@@ -7,6 +7,7 @@ permissions:
   packages: write
 
 repositories:
+  - autogov
   - liatrio-gh-autogov-workflows
   - liatrio-gh-autogov-caller-workflows
   - demo-gh-autogov-workflows


### PR DESCRIPTION
Grants the release-ops identity (contents:write on main) to the `autogov` repo so its self-release workflow (#245) can push the release commit to its protected main, matching the policy-library release pattern. Paired with adding the octo-sts app to autogov's `main protection` ruleset bypass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release operations configuration to include an additional repository entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->