### PR TITLE
chore: rename-prep — add autogov-workflows/autogov-policy-library to octo-sts trust (merge BEFORE rename; non-breaking)

### DIFF
--- a/.github/chainguard/autogov-infra.sts.yaml
+++ b/.github/chainguard/autogov-infra.sts.yaml
@@ -9,8 +9,10 @@ repositories:
   - autogov
   - autogov-solutions
   - liatrio-rego-policy-library
+  - autogov-policy-library
   - demo-gh-autogov-policy-library
   - k8s-platform-v3-ingress-auth-demo
   - liatrio-gh-autogov-workflows
+  - autogov-workflows
   - demo-gh-autogov-workflows
   - hello-autogov

--- a/.github/chainguard/autogov-milestones.sts.yaml
+++ b/.github/chainguard/autogov-milestones.sts.yaml
@@ -13,7 +13,9 @@ repositories:
   - demo-gh-autogov-workflows
   - demo-ootb-backstage
   - liatrio-gh-autogov-workflows
+  - autogov-workflows
   - liatrio-rego-policy-library
+  - autogov-policy-library
   - autogov-helper
   - autogov-verify
   - tag-automated-governance-docs

--- a/.github/chainguard/release-ops.sts.yaml
+++ b/.github/chainguard/release-ops.sts.yaml
@@ -9,8 +9,10 @@ permissions:
 repositories:
   - autogov
   - liatrio-gh-autogov-workflows
+  - autogov-workflows
   - liatrio-gh-autogov-caller-workflows
   - demo-gh-autogov-workflows
   - demo-gh-autogov-caller-workflows
   - liatrio-rego-policy-library
+  - autogov-policy-library
   - demo-gh-autogov-policy-library


### PR DESCRIPTION
## what

Adds the post-rename repo names to the octo-sts trust policies **alongside** the current names:

- `liatrio-gh-autogov-workflows` → also add `autogov-workflows`
- `liatrio-rego-policy-library` → also add `autogov-policy-library`

Touched files in `.github/chainguard/`:

- `autogov-infra.sts.yaml` — add `autogov-workflows`, `autogov-policy-library`
- `release-ops.sts.yaml` — add `autogov-workflows`, `autogov-policy-library`
- `autogov-milestones.sts.yaml` — add `autogov-workflows`, `autogov-policy-library`

## safe to merge BEFORE the rename

Unlike the other rename-prep PRs (which are lockstep-after-rename), **this one is safe to merge before the repos are renamed.** It only *adds* entries — the old names keep working during the transition, and the new entries become harmless no-ops until the rename happens (after which the old entries become the harmless no-ops). Nothing here removes or breaks existing trust.

The old entries are intentionally left in place; they can be cleaned up in a later follow-up once the renames are complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository allowlists across multiple automation workflow configuration files to enable additional repositories for automated infrastructure management, milestone processing, and release operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->