### PR TITLE
chore: drop archived/dead repos from octo-sts trust

### DIFF
--- a/.github/chainguard/autogov-milestones.sts.yaml
+++ b/.github/chainguard/autogov-milestones.sts.yaml
@@ -7,11 +7,7 @@ permissions:
 repositories:
   - backstage-plugin-autogov
   - demo-autogov-hello-world-app
-  - demo-gh-attest-autogov
-  - demo-ootb-backstage
   - autogov-workflows
   - autogov-policy-library
-  - autogov-helper
-  - autogov-verify
   - tag-automated-governance-docs
   - tag-automated-governance-manifests

--- a/.github/chainguard/release-ops.sts.yaml
+++ b/.github/chainguard/release-ops.sts.yaml
@@ -9,5 +9,4 @@ permissions:
 repositories:
   - autogov
   - autogov-workflows
-  - liatrio-gh-autogov-caller-workflows
   - autogov-policy-library


### PR DESCRIPTION
caller-workflows has no release workflow (no release-ops write needed); autogov-helper archived; autogov-verify redirects to autogov (dead name); demo-gh-attest-autogov + demo-ootb-backstage archived.