### PR TITLE
chore: add autogov-caller-workflows to release-ops trust

### DIFF
--- a/.github/chainguard/release-ops.sts.yaml
+++ b/.github/chainguard/release-ops.sts.yaml
@@ -10,3 +10,4 @@ repositories:
   - autogov
   - autogov-workflows
   - autogov-policy-library
+  - autogov-caller-workflows


### PR DESCRIPTION
the renamed caller self-releases (release-cut) → needs release-ops contents:write; re-add under new name (earlier cleanup over-pruned it).