### PR TITLE
chore: drop archived k8s-platform-v3-ingress-auth-demo from autogov-infra trust

### DIFF
--- a/.github/chainguard/autogov-infra.sts.yaml
+++ b/.github/chainguard/autogov-infra.sts.yaml
@@ -9,6 +9,5 @@ repositories:
   - autogov
   - autogov-solutions
   - autogov-policy-library
-  - k8s-platform-v3-ingress-auth-demo
   - autogov-workflows
   - hello-autogov


### PR DESCRIPTION
k8s-platform-v3-ingress-auth-demo is archived; remove it from the autogov-infra octo-sts repositories scope (matches the earlier archived-repo cleanup).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository authorization configuration for automated workflows to support new repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->