### PR TITLE
chore: drop archived repos from autogov-milestones trust

### DIFF
--- a/.github/chainguard/autogov-milestones.sts.yaml
+++ b/.github/chainguard/autogov-milestones.sts.yaml
@@ -5,8 +5,6 @@ permissions:
   issues: write
 
 repositories:
-  - backstage-plugin-autogov
-  - demo-autogov-hello-world-app
   - autogov-workflows
   - autogov-policy-library
   - tag-automated-governance-docs


### PR DESCRIPTION
backstage-plugin-autogov and demo-autogov-hello-world-app are archived; remove them from the autogov-milestones octo-sts scope (issues:write can't target archived repos).