### PR TITLE
feat: add contents: read to liatrio-get-all-docs STS identity

### DIFF
--- a/.github/chainguard/liatrio-get-all-docs.sts.yaml
+++ b/.github/chainguard/liatrio-get-all-docs.sts.yaml
@@ -5,3 +5,4 @@ subject_pattern: "repo:liatrio/get-all-docs:.*"
 permissions:
   metadata: read
   pages: read
+  contents: read


### PR DESCRIPTION
## Summary

- Adds `contents: read` to the `liatrio-get-all-docs` Octo-STS identity permissions
- Enables the `get-all-docs` doc generation workflow to fetch README content from private/internal org repos via `GET /repos/{org}/{repo}/readme`
- Previously only `metadata: read` and `pages: read` were granted, so README fetches silently returned empty for all non-public repos

## Test plan

- [ ] Merge this PR first
- [ ] Then push/deploy `liatrio/get-all-docs` — confirm per-site detail pages for private repos now include README content

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository access permissions for an automated workflow so it can read content in addition to existing page and metadata access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->